### PR TITLE
fix PHP short form tags

### DIFF
--- a/seed-fonts.php
+++ b/seed-fonts.php
@@ -138,7 +138,7 @@ function seed_fonts_hidden_weight_options() {
 		foreach( $_font_desc["weights"] as $_weight ) { ?>		
 		<option value="<?php esc_html_e( $_weight, 'seed-fonts' ); ?>"><?php esc_html_e( $_weight, 'seed-fonts' ); ?></option><?php		
 		} ?>
-	</select> <?
+	</select> <?php
 	}
 }
 


### PR DESCRIPTION
PHP short form tags may cause fatal error on some environment such as #5 
